### PR TITLE
Fixing generate_molecular_data_and_baselines.ipynb

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ This repository contains the codebase developed for the paper [Autoregressive ne
 
 #### TL;DR
 
-*Certain parts of the notebooks relating to generating molecular data are currently not working due to updates to the underlying OpenFermion and Psi4 packages (I'll fix it!) - however the experimental results of NAQS can still be reproduced as we also provide pre-generated data in this repository.*
-
 If you don't care for now, and you just want to see it running, here are two links to notebooks that will set-up and run on Colab.  Just note that Colab will not have enough memory to run experiments on the largest molecules we considered.
 
 - [run_naqs.ipynb](notebooks/run_naqs.ipynb) [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/tomdbar/naqs-for-quantum-chemistry/blob/main/notebooks/run_naqs.ipynb): Run individual experiments or batches of experiments, including those to recreate published results.

--- a/notebooks/generate_molecular_data_and_baselines.ipynb
+++ b/notebooks/generate_molecular_data_and_baselines.ipynb
@@ -33,16 +33,13 @@
    "source": [
     "import sys\n",
     "\n",
-    "# OpenFermion installation.\n",
-    "# !pip install openfermion openfermionpsi4 openfermioncirq pyscf openfermionpyscf\n",
-    "\n",
     "# Conda env creation and Psi 4 installation.\n",
-    "# !pip install openfermion==0.11.0 openfermionpsi4 openfermioncirq pyscf openfermionpyscf\n",
     "!wget https://repo.continuum.io/miniconda/Miniconda3-4.5.4-Linux-x86_64.sh\n",
     "!bash Miniconda3-4.5.4-Linux-x86_64.sh -bfp /usr/local\n",
     "sys.path.append('/usr/local/lib/python3.6/site-packages')\n",
-    "!conda install -c psi4 psi4 -y\n",
-    "!pip install openfermion==0.11.0 openfermionpsi4 openfermioncirq pyscf openfermionpyscf"
+    "!conda install -q -y python=3.6\n",
+    "!conda install -c psi4 psi4=1.3.* -y\n",
+    "!pip install openfermion==0.11.0 openfermionpsi4==0.3.*"
    ]
   },
   {
@@ -54,11 +51,8 @@
    },
    "outputs": [],
    "source": [
-    "# OpenFermionPsi4\n",
-    "# Import opemfermionpsi4\n",
     "import openfermion as of\n",
     "import openfermionpsi4 as ofpsi4\n",
-    "import openfermionpyscf as ofpyscf\n",
     "\n",
     "from openfermion.hamiltonians import MolecularData\n",
     "from openfermion.utils import geometry_from_pubchem\n",


### PR DESCRIPTION
Pinning versions in notebooks/generate_molecular_data_and_baselines.ipynb.